### PR TITLE
Se arregla Error ENOENT: no such file or directory

### DIFF
--- a/src/XMLDsig.ts
+++ b/src/XMLDsig.ts
@@ -122,7 +122,10 @@ class XMLDsig {
             }
 
             try {
-              fs.unlinkSync(tmpXMLToSign);
+              // Justo Gonzalez - consulta primero si existe, generabar Error: ENOENT: no such file or directory, unlink 
+              if (tmpXMLToSign) {
+                fs.unlinkSync(tmpXMLToSign);
+              }
               //file removed
             } catch (err) {
               console.error(err);
@@ -177,7 +180,10 @@ class XMLDsig {
             }
 
             try {
-              fs.unlinkSync(tmpXMLToSign);
+            // Justo Gonzalez - consulta primero si existe, generabar Error: ENOENT: no such file or directory, unlink 
+              if (tmpXMLToSign) {
+                fs.unlinkSync(tmpXMLToSign);
+              }
               //file removed
             } catch (err) {
               console.error(err);


### PR DESCRIPTION
Se arregla Error ENOENT: no such file or directory,  Generaba error al no encontrar el file. Nos aseguramos que exista antes de intentar eliminarlo. Sucedia en caso de generar por lotes.